### PR TITLE
Make CRC check configurable

### DIFF
--- a/components/atorch_dl24/atorch_dl24.cpp
+++ b/components/atorch_dl24/atorch_dl24.cpp
@@ -96,7 +96,7 @@ void AtorchDL24::decode_(const uint8_t *data, uint16_t length) {
     return (uint32_t(dl24_get_16bit(i + 0)) << 16) | (uint32_t(dl24_get_16bit(i + 2)) << 0);
   };
 
-  if (crc(data, length - 1) != data[35]) {
+  if (this->check_crc_ && crc(data, length - 1) != data[35]) {
     ESP_LOGW(TAG, "CRC check failed. Skipping frame.");
     return;
   }

--- a/components/atorch_dl24/atorch_dl24.h
+++ b/components/atorch_dl24/atorch_dl24.h
@@ -30,6 +30,8 @@ class AtorchDL24 : public esphome::ble_client::BLEClientNode, public Component {
   void set_dim_backlight_sensor(sensor::Sensor *dim_backlight_sensor) { dim_backlight_sensor_ = dim_backlight_sensor; }
   void set_running_sensor(sensor::Sensor *running_sensor) { running_sensor_ = running_sensor; }
 
+  void set_check_crc(bool check_crc) { check_crc_ = check_crc; }
+
  protected:
   void decode_(const uint8_t *data, uint16_t length);
   void publish_state_(sensor::Sensor *sensor, float value);
@@ -43,6 +45,9 @@ class AtorchDL24 : public esphome::ble_client::BLEClientNode, public Component {
   sensor::Sensor *temperature_sensor_{nullptr};
   sensor::Sensor *dim_backlight_sensor_{nullptr};
   sensor::Sensor *running_sensor_{nullptr};
+
+  bool check_crc_;
+
   uint8_t previous_value_ = 61;
 };
 

--- a/components/atorch_dl24/sensor.py
+++ b/components/atorch_dl24/sensor.py
@@ -30,8 +30,10 @@ from esphome.const import (
 
 CODEOWNERS = ["@syssi"]
 
+CONF_CHECK_CRC = "check_crc"
 CONF_DIM_BACKLIGHT = "dim_backlight"
 CONF_RUNNING = "running"
+
 UNIT_AMPERE_HOURS = "Ah"
 ICON_CAPACITY = "mdi:battery-medium"
 ICON_RUNNING = "mdi:power"
@@ -53,6 +55,7 @@ AtorchDL24 = atorch_dl24_ns.class_("AtorchDL24", ble_client.BLEClientNode, cg.Co
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(AtorchDL24),
+        cv.Optional(CONF_CHECK_CRC, default=True): cv.boolean,
         cv.Optional(CONF_VOLTAGE): sensor.sensor_schema(
             UNIT_VOLT, ICON_EMPTY, 1, DEVICE_CLASS_VOLTAGE, STATE_CLASS_MEASUREMENT
         ),
@@ -109,6 +112,8 @@ def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     yield cg.register_component(var, config)
     yield ble_client.register_ble_node(var, config)
+
+    cg.add(var.set_check_crc(config[CONF_CHECK_CRC]))
 
     for key in SENSORS:
         if key in config:

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -32,6 +32,7 @@ ble_client:
 sensor:
   - platform: atorch_dl24
     ble_client_id: dummyload0
+    check_crc: true
     voltage:
       name: "${name} voltage"
     current:


### PR DESCRIPTION
Introduces a new config option to disable the CRC check:

```
  - platform: atorch_dl24
    ble_client_id: dummyload0
    check_crc: true
```