### PR TITLE
Composite notification values (Closes: #10)

### DIFF
--- a/components/atorch_dl24/atorch_dl24.cpp
+++ b/components/atorch_dl24/atorch_dl24.cpp
@@ -82,7 +82,6 @@ void AtorchDL24::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t g
       // FF.55.01.02.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00 (20)
       if (!this->incomplete_notify_value_received_ && param->notify.value_len == 20 && param->notify.value[0] == 0xFF &&
           param->notify.value[1] == 0x55) {
-        ESP_LOGD(TAG, "Incomplete frame stored");
         memcpy(this->composite_notfiy_value_, param->notify.value, param->notify.value_len);
         this->incomplete_notify_value_received_ = true;
         break;
@@ -90,7 +89,6 @@ void AtorchDL24::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t g
 
       // 00.00.00.00.00.1E.00.00.00.00.3C.00.00.00.00.19 (16)
       if (this->incomplete_notify_value_received_ && param->notify.value_len == 16) {
-        ESP_LOGD(TAG, "Incomplete frame completed");
         memcpy(this->composite_notfiy_value_ + 20, param->notify.value, param->notify.value_len);
         // FF.55.01.02.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.1E.00.00.00.00.3C.00.00.00.00.19
         this->decode_(this->composite_notfiy_value_, 36);

--- a/components/atorch_dl24/atorch_dl24.cpp
+++ b/components/atorch_dl24/atorch_dl24.cpp
@@ -75,7 +75,8 @@ void AtorchDL24::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t g
       if (param->notify.handle != this->char_handle_)
         break;
 
-      ESP_LOGVV(TAG, "Notification received: %s", hexencode(param->notify.value, param->notify.value_len + 0).c_str());
+      ESP_LOGVV(TAG, "Notification received: %s",
+                format_hex_pretty(param->notify.value, param->notify.value_len + 0).c_str());
 
       // Composite two short notifications into a complete one
       // FF.55.01.02.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00 (20)

--- a/components/atorch_dl24/atorch_dl24.cpp
+++ b/components/atorch_dl24/atorch_dl24.cpp
@@ -82,7 +82,7 @@ void AtorchDL24::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t g
       // FF.55.01.02.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00 (20)
       if (!this->incomplete_notify_value_received_ && param->notify.value_len == 20 && param->notify.value[0] == 0xFF &&
           param->notify.value[1] == 0x55) {
-        ESP_LOGD(TAG, "Incomplete frame stored")
+        ESP_LOGD(TAG, "Incomplete frame stored");
         memcpy(this->composite_notfiy_value_, param->notify.value, param->notify.value_len);
         this->incomplete_notify_value_received_ = true;
         break;
@@ -90,7 +90,7 @@ void AtorchDL24::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t g
 
       // 00.00.00.00.00.1E.00.00.00.00.3C.00.00.00.00.19 (16)
       if (this->incomplete_notify_value_received_ && param->notify.value_len == 16) {
-        ESP_LOGD(TAG, "Incomplete frame completed")
+        ESP_LOGD(TAG, "Incomplete frame completed");
         memcpy(this->composite_notfiy_value_ + 20, param->notify.value, param->notify.value_len);
         // FF.55.01.02.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.1E.00.00.00.00.3C.00.00.00.00.19
         this->decode_(this->composite_notfiy_value_, 36);

--- a/components/atorch_dl24/atorch_dl24.cpp
+++ b/components/atorch_dl24/atorch_dl24.cpp
@@ -80,7 +80,7 @@ void AtorchDL24::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t g
 
       // Composite two short notifications into a complete one
       // FF.55.01.02.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00 (20)
-      if (!incomplete_notify_value_received_ && param->notify.value_len == 20 && param->notify.value[0] == 0xFF &&
+      if (!this->incomplete_notify_value_received_ && param->notify.value_len == 20 && param->notify.value[0] == 0xFF &&
           param->notify.value[1] == 0x55) {
         memcpy(this->composite_notfiy_value_, param->notify.value, param->notify.value_len);
         this->incomplete_notify_value_received_ = true;

--- a/components/atorch_dl24/atorch_dl24.cpp
+++ b/components/atorch_dl24/atorch_dl24.cpp
@@ -82,6 +82,7 @@ void AtorchDL24::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t g
       // FF.55.01.02.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00 (20)
       if (!this->incomplete_notify_value_received_ && param->notify.value_len == 20 && param->notify.value[0] == 0xFF &&
           param->notify.value[1] == 0x55) {
+        ESP_LOGD(TAG, "Incomplete frame stored")
         memcpy(this->composite_notfiy_value_, param->notify.value, param->notify.value_len);
         this->incomplete_notify_value_received_ = true;
         break;
@@ -89,6 +90,7 @@ void AtorchDL24::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t g
 
       // 00.00.00.00.00.1E.00.00.00.00.3C.00.00.00.00.19 (16)
       if (this->incomplete_notify_value_received_ && param->notify.value_len == 16) {
+        ESP_LOGD(TAG, "Incomplete frame completed")
         memcpy(this->composite_notfiy_value_ + 20, param->notify.value, param->notify.value_len);
         // FF.55.01.02.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.1E.00.00.00.00.3C.00.00.00.00.19
         this->decode_(this->composite_notfiy_value_, 36);

--- a/components/atorch_dl24/atorch_dl24.h
+++ b/components/atorch_dl24/atorch_dl24.h
@@ -47,8 +47,10 @@ class AtorchDL24 : public esphome::ble_client::BLEClientNode, public Component {
   sensor::Sensor *running_sensor_{nullptr};
 
   bool check_crc_;
+  bool incomplete_notify_value_received_ = false;
 
   uint8_t previous_value_ = 61;
+  uint8_t composite_notfiy_value_[36];
 };
 
 }  // namespace atorch_dl24


### PR DESCRIPTION
```
external_components:
  - source: github://syssi/esphome-atorch-dl24@composite-frames
    refresh: 0s
```