### PR TITLE
Convert the running sensor to a binary sensor (Closes: #29)

### DIFF
--- a/components/atorch_dl24/__init__.py
+++ b/components/atorch_dl24/__init__.py
@@ -14,6 +14,12 @@ CONF_CHECK_CRC = "check_crc"
 atorch_dl24_ns = cg.esphome_ns.namespace("atorch_dl24")
 AtorchDL24 = atorch_dl24_ns.class_("AtorchDL24", ble_client.BLEClientNode, cg.Component)
 
+ATORCH_DL24_COMPONENT_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_ATORCH_DL24_ID): cv.use_id(AtorchDL24),
+    }
+)
+
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(AtorchDL24),

--- a/components/atorch_dl24/atorch_dl24.h
+++ b/components/atorch_dl24/atorch_dl24.h
@@ -3,6 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/ble_client/ble_client.h"
 #include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
+#include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 
@@ -21,6 +22,10 @@ class AtorchDL24 : public esphome::ble_client::BLEClientNode, public Component {
                            esp_ble_gattc_cb_param_t *param) override;
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::DATA; }
+
+  void set_running_binary_sensor(binary_sensor::BinarySensor *running_binary_sensor) {
+    running_binary_sensor_ = running_binary_sensor;
+  }
 
   void set_voltage_sensor(sensor::Sensor *voltage_sensor) { voltage_sensor_ = voltage_sensor; }
   void set_current_sensor(sensor::Sensor *current_sensor) { current_sensor_ = current_sensor; }
@@ -67,7 +72,8 @@ class AtorchDL24 : public esphome::ble_client::BLEClientNode, public Component {
            (seconds ? to_string(seconds) + "s" : "");
   }
 
-  uint16_t char_handle_;
+  binary_sensor::BinarySensor *running_binary_sensor_;
+
   sensor::Sensor *voltage_sensor_{nullptr};
   sensor::Sensor *current_sensor_{nullptr};
   sensor::Sensor *power_sensor_{nullptr};
@@ -90,6 +96,7 @@ class AtorchDL24 : public esphome::ble_client::BLEClientNode, public Component {
 
   uint8_t previous_value_ = 61;
   uint8_t composite_notfiy_value_[36];
+  uint16_t char_handle_;
 };
 
 }  // namespace atorch_dl24

--- a/components/atorch_dl24/atorch_dl24.h
+++ b/components/atorch_dl24/atorch_dl24.h
@@ -54,6 +54,7 @@ class AtorchDL24 : public esphome::ble_client::BLEClientNode, public Component {
  protected:
   void decode_ac_and_dc_(const uint8_t *data, uint16_t length);
   void decode_usb_(const uint8_t *data, uint16_t length);
+  void publish_state_(binary_sensor::BinarySensor *binary_sensor, const bool &state);
   void publish_state_(sensor::Sensor *sensor, float value);
   void publish_state_(text_sensor::TextSensor *text_sensor, const std::string &state);
 

--- a/components/atorch_dl24/binary_sensor.py
+++ b/components/atorch_dl24/binary_sensor.py
@@ -1,0 +1,47 @@
+import esphome.codegen as cg
+from esphome.components import binary_sensor
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ENTITY_CATEGORY,
+    CONF_ICON,
+    CONF_ID,
+    ENTITY_CATEGORY_DIAGNOSTIC,
+)
+
+from . import ATORCH_DL24_COMPONENT_SCHEMA, CONF_ATORCH_DL24_ID
+
+DEPENDENCIES = ["atorch_dl24"]
+
+CODEOWNERS = ["@syssi"]
+
+CONF_RUNNING = "running"
+
+ICON_RUNNING = "mdi:power"
+
+BINARY_SENSORS = [
+    CONF_RUNNING,
+]
+
+CONFIG_SCHEMA = ATORCH_DL24_COMPONENT_SCHEMA.extend(
+    {
+        cv.Optional(CONF_RUNNING): binary_sensor.BINARY_SENSOR_SCHEMA.extend(
+            {
+                cv.GenerateID(): cv.declare_id(binary_sensor.BinarySensor),
+                cv.Optional(CONF_ICON, default=ICON_RUNNING): cv.icon,
+                cv.Optional(
+                    CONF_ENTITY_CATEGORY, default=ENTITY_CATEGORY_DIAGNOSTIC
+                ): cv.entity_category,
+            }
+        ),
+    }
+)
+
+
+async def to_code(config):
+    hub = await cg.get_variable(config[CONF_ATORCH_DL24_ID])
+    for key in BINARY_SENSORS:
+        if key in config:
+            conf = config[key]
+            sens = cg.new_Pvariable(conf[CONF_ID])
+            await binary_sensor.register_binary_sensor(sens, conf)
+            cg.add(getattr(hub, f"set_{key}_binary_sensor")(sens))

--- a/components/atorch_dl24/sensor.py
+++ b/components/atorch_dl24/sensor.py
@@ -34,7 +34,7 @@ from esphome.const import (
     UNIT_WATT_HOURS,
 )
 
-from . import CONF_ATORCH_DL24_ID, AtorchDL24
+from . import ATORCH_DL24_COMPONENT_SCHEMA, CONF_ATORCH_DL24_ID
 
 DEPENDENCIES = ["atorch_dl24"]
 
@@ -72,9 +72,8 @@ SENSORS = [
 
 
 # pylint: disable=too-many-function-args
-CONFIG_SCHEMA = cv.Schema(
+CONFIG_SCHEMA = ATORCH_DL24_COMPONENT_SCHEMA.extend(
     {
-        cv.GenerateID(CONF_ATORCH_DL24_ID): cv.use_id(AtorchDL24),
         cv.Optional(CONF_VOLTAGE): sensor.sensor_schema(
             unit_of_measurement=UNIT_VOLT,
             icon=ICON_EMPTY,

--- a/components/atorch_dl24/text_sensor.py
+++ b/components/atorch_dl24/text_sensor.py
@@ -3,7 +3,7 @@ from esphome.components import text_sensor
 import esphome.config_validation as cv
 from esphome.const import CONF_ICON, CONF_ID, ICON_TIMELAPSE
 
-from . import CONF_ATORCH_DL24_ID, AtorchDL24
+from . import ATORCH_DL24_COMPONENT_SCHEMA, CONF_ATORCH_DL24_ID
 
 DEPENDENCIES = ["atorch_dl24"]
 
@@ -15,9 +15,8 @@ TEXT_SENSORS = [
     CONF_RUNTIME_FORMATTED,
 ]
 
-CONFIG_SCHEMA = cv.Schema(
+CONFIG_SCHEMA = ATORCH_DL24_COMPONENT_SCHEMA.extend(
     {
-        cv.GenerateID(CONF_ATORCH_DL24_ID): cv.use_id(AtorchDL24),
         cv.Optional(CONF_RUNTIME_FORMATTED): text_sensor.TEXT_SENSOR_SCHEMA.extend(
             {
                 cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),

--- a/esp32-ac-meter-example.yaml
+++ b/esp32-ac-meter-example.yaml
@@ -40,6 +40,12 @@ atorch_dl24:
     ble_client_id: ble_client0
     check_crc: true
 
+binary_sensor:
+  - platform: atorch_dl24
+    atorch_dl24_id: atorch0
+    running:
+      name: "${name} running"
+
 sensor:
   - platform: atorch_dl24
     atorch_dl24_id: atorch0
@@ -57,8 +63,6 @@ sensor:
       name: "${name} temperature"
     dim_backlight:
       name: "${name} dim backlight"
-    running:
-      name: "${name} running"
     frequency:
       name: "${name} frequency"
     power_factor:

--- a/esp32-dc-meter-example.yaml
+++ b/esp32-dc-meter-example.yaml
@@ -40,6 +40,12 @@ atorch_dl24:
     ble_client_id: ble_client0
     check_crc: true
 
+binary_sensor:
+  - platform: atorch_dl24
+    atorch_dl24_id: atorch0
+    running:
+      name: "${name} running"
+
 sensor:
   - platform: atorch_dl24
     atorch_dl24_id: atorch0

--- a/esp32-usb-meter-example.yaml
+++ b/esp32-usb-meter-example.yaml
@@ -40,6 +40,12 @@ atorch_dl24:
     ble_client_id: ble_client0
     check_crc: true
 
+binary_sensor:
+  - platform: atorch_dl24
+    atorch_dl24_id: atorch0
+    running:
+      name: "${name} running"
+
 sensor:
   - platform: atorch_dl24
     atorch_dl24_id: atorch0


### PR DESCRIPTION
The running sensor isn't removed to avoid a breaking change.