### PR TITLE
Improve Atorch J7-C support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ ESPHome component to monitor and control some Atorch meters via bluetooth
 
 * Atorch DL24
 * Atorch DL24P
+* Atorch J7-C
 
 ## Supported but untested devices
 
@@ -25,7 +26,6 @@ ESPHome component to monitor and control some Atorch meters via bluetooth
 * Atorch UD18
 * Atorch UD18-L
 * Atorch T18
-* Atorch J7-C
 * Atorch J7-H
 
 ## Unsupported devices because of a different protocol

--- a/README.md
+++ b/README.md
@@ -15,7 +15,13 @@ ESPHome component to monitor and control some Atorch meters via bluetooth
 
 * Atorch DL24
 * Atorch DL24P
-* Atorch J7-C
+* Atorch J7-C requires a disabled CRC check
+  ```
+  atorch_dl24:
+    - id: atorch0
+      ble_client_id: ble_client0
+      check_crc: false
+  ```
 
 ## Supported but untested devices
 

--- a/components/atorch_dl24/atorch_dl24.cpp
+++ b/components/atorch_dl24/atorch_dl24.cpp
@@ -291,42 +291,44 @@ void AtorchDL24::decode_ac_and_dc_(const uint8_t *data, uint16_t length) {
   // FF.55.01.02.00.00.20.00.4E.20.00.13.FC.00.00.00.11.00.00.00.00.00.00.00.00.25.00.02.21.1D.3C.00.00.00.00.16
   // FF.55.01.02.00.00.20.00.4E.1B.00.13.FC.00.00.00.11.00.00.00.00.00.00.00.00.25.00.02.21.1E.3C.00.00.00.00.0A
   // FF.55.01.02.00.00.20.00.4E.23.00.13.FD.00.00.00.11.00.00.00.00.00.00.00.00.25.00.02.21.1F.3C.00.00.00.00.1C
+  //  0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35
   //
-  // 0xFF 0x55:            Magic header
-  // 0x01:                 Message type           0x01: Report (32 byte), 0x02: Reply (4 byte), 0x11: Command (6 byte)
-  // 0x02:                 Device type            0x01: AC meter, 0x02: DC meter, 0x03: USB meter
-  // 0x00 0x00 0x20:       Voltage                32 * 0.1 = 3.2 V
+  // Byte Len Payload              Description
+  //  0    2  0xFF 0x55            Magic header
+  //  2    1  0x01                 Message type           0x01: Report (32 byte), 0x02: Reply (4 byte), 0x11: Command (6 byte)
+  //  3    1  0x02                 Device type            0x01: AC meter, 0x02: DC meter, 0x03: USB meter
+  //  4    3  0x00 0x00 0x20       Voltage                32 * 0.1 = 3.2 V
   float voltage = dl24_get_24bit(4) * 0.1f;
   this->publish_state_(this->voltage_sensor_, voltage);
 
-  // 0x00 0x4E 0x23:       Current                20003 * 0.001 = 20.003 A
+  //  7    3  0x00 0x4E 0x23       Current                20003 * 0.001 = 20.003 A
   float current = dl24_get_24bit(7) * 0.001f;
   this->publish_state_(this->current_sensor_, current);
   this->publish_state_(this->power_sensor_, voltage * current);
 
-  // 0x00 0x13 0xFD:       Capacity in Ah        5117 * 0.01 = 51.17 Ah
+  // 10    3  0x00 0x13 0xFD       Capacity in Ah        5117 * 0.01 = 51.17 Ah
   this->publish_state_(this->capacity_sensor_, dl24_get_24bit(10) * 0.01f);
 
-  // 0x00 0x00 0x00 0x11:  Energy in Wh           17 * 10.0 = 170.0
+  // 13    4  0x00 0x00 0x00 0x11  Energy in Wh           17 * 10.0 = 170.0
   this->publish_state_(this->energy_sensor_, dl24_get_32bit(13) * 10.0f);
 
   if (data[3] == DEVICE_TYPE_AC_METER) {
-    // 0x00 0x00 0x00:       Price per kWh          value * 0.01
+    // 17    3  0x00 0x00 0x00       Price per kWh          value * 0.01
     this->publish_state_(this->price_per_kwh_sensor_, dl24_get_24bit(17) * 0.01f);
 
-    // 0x00 0x00:            Frequency              value * 0.1 Hz
+    // 20    2  0x00 0x00            Frequency              value * 0.1 Hz
     this->publish_state_(this->frequency_sensor_, dl24_get_16bit(20) * 0.1f);
 
-    // 0x00 0x00:            Power factor           value * 0.001
+    // 22    2  0x00 0x00            Power factor           value * 0.001
     this->publish_state_(this->power_factor_sensor_, dl24_get_16bit(22) * 0.001f);
   }
 
-  // 0x00 0x25:            Temperature            37 °C
+  // 24    2  0x00 0x25            Temperature            37 °C
   this->publish_state_(this->temperature_sensor_, (float) dl24_get_16bit(24));
 
-  // 0x00 0x02:            Hour                   2 h
-  // 0x21:                 Minute                 33 min
-  // 0x1F:                 Second                 31 sec
+  // 26    2  0x00 0x02            Hour                   2 h
+  // 28    1  0x21                 Minute                 33 min
+  // 29    1  0x1F                 Second                 31 sec
   uint32_t runtime = (dl24_get_16bit(26) * 3600) + (data[28] * 60) + data[29];
   this->publish_state_(this->runtime_sensor_, (float) runtime);
   if (this->runtime_formatted_text_sensor_ != nullptr) {
@@ -340,11 +342,11 @@ void AtorchDL24::decode_ac_and_dc_(const uint8_t *data, uint16_t length) {
   }
   previous_value_ = data[29];
 
-  // 0x3C:                 Dim backlight          60 seconds
+  // 30    1  0x3C                 Dim backlight          60 seconds
   this->publish_state_(this->dim_backlight_sensor_, (float) data[30]);
 
-  // 0x00 0x00 0x00 0x00:  Unknown
-  // 0x1C:                 Checksum
+  // 31    4  0x00 0x00 0x00 0x00  Unknown
+  // 35    1  0x1C                 Checksum
 }
 
 void AtorchDL24::decode_usb_(const uint8_t *data, uint16_t length) {
@@ -364,37 +366,39 @@ void AtorchDL24::decode_usb_(const uint8_t *data, uint16_t length) {
   // FF.55.01.03.00.01.FB.00.00.00.00.3C.C7.00.00.55.4E.00.07.00.07.00.00.00.47.2F.24.3C.00.00.00.00.00.00.00.CE
   // FF.55.01.03.00.01.CD.00.00.7F.00.3C.C8.00.00.55.4E.00.09.00.0A.00.00.00.47.30.0D.3C.00.00.00.00.00.00.00.8F
   // FF.55.01.03.00.01.FB.00.00.01.00.6C.3F.00.00.6C.44.00.07.00.06.00.1A.00.47.1C.1A.3C.00.00.00.00.00.00.00.78
+  //  0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35
   //
-  // 0xFF 0x55:            Magic header
-  // 0x01:                 Message type           0x01: Report (32 byte), 0x02: Reply (4 byte), 0x11: Command (6 byte)
-  // 0x03:                 Device type            0x01: AC meter, 0x02: DC meter, 0x03: USB meter
-  // 0x00 0x01 0xF3:       Voltage                499 * 0.01 = 4.99 V
+  // Byte Len Payload              Description
+  //  0    2  0xFF 0x55            Magic header
+  //  2    1  0x01                 Message type           0x01: Report (32 byte), 0x02: Reply (4 byte), 0x11: Command (6 byte)
+  //  3    1  0x03                 Device type            0x01: AC meter, 0x02: DC meter, 0x03: USB meter
+  //  4    3  0x00 0x01 0xF3       Voltage                499 * 0.01 = 4.99 V
   float voltage = dl24_get_24bit(4) * 0.01f;
   this->publish_state_(this->voltage_sensor_, voltage);
 
-  // 0x00 0x00 0x00:       Current                0 * 0.01 = 0.00 A
+  //  7    3  0x00 0x00 0x00       Current                0 * 0.01 = 0.00 A
   float current = dl24_get_24bit(7) * 0.01f;
   this->publish_state_(this->current_sensor_, current);
   this->publish_state_(this->power_sensor_, voltage * current);
 
-  // 0x00 0x06 0x38:       Capacity in Ah         1592 * 0.001 = 1.592 Ah
+  // 10    3  0x00 0x06 0x38       Capacity in Ah         1592 * 0.001 = 1.592 Ah
   this->publish_state_(this->capacity_sensor_, dl24_get_24bit(10) * 0.001f);
 
-  // 0x00 0x00 0x03 0x11:  Energy in Wh           785 * 0.01 = 7.85 Wh
+  // 13    4  0x00 0x00 0x03 0x11  Energy in Wh           785 * 0.01 = 7.85 Wh
   this->publish_state_(this->energy_sensor_, dl24_get_32bit(13) * 0.01f);
 
-  // 0x00 0x07:            USB D-                 7 * 0.01 = 0,07 V
+  // 17    2  0x00 0x07            USB D-                 7 * 0.01 = 0,07 V
   this->publish_state_(this->usb_data_minus_sensor_, (float) dl24_get_16bit(17) * 0.01f);
 
-  // 0x00 0x0A:            USB D+                 10 * 0.01 = 0,10 V
+  // 19    2  0x00 0x0A            USB D+                 10 * 0.01 = 0,10 V
   this->publish_state_(this->usb_data_plus_sensor_, (float) dl24_get_16bit(19) * 0.01f);
 
-  // 0x00 0x00 0x00:       Temperature
-  this->publish_state_(this->temperature_sensor_, (float) dl24_get_24bit(21));
+  // 21    2  0x00 0x00            Temperature
+  this->publish_state_(this->temperature_sensor_, (float) dl24_get_16bit(21));
 
-  // 0x12 0x2E:            Hour                   4654 h
-  // 0x33:                 Minute                 51 min
-  // 0x3C:                 Second                 60 sec
+  // 23    2  0x00 0x12            Hour                   18 h
+  // 25    1  0x2E                 Minute                 46 min
+  // 26    1  0x33                 Second                 51 sec
   uint32_t runtime = (dl24_get_16bit(23) * 3600) + (data[25] * 60) + data[26];
   this->publish_state_(this->runtime_sensor_, (float) runtime);
   if (this->runtime_formatted_text_sensor_ != nullptr) {
@@ -408,11 +412,11 @@ void AtorchDL24::decode_usb_(const uint8_t *data, uint16_t length) {
   }
   previous_value_ = data[26];
 
-  // 0x00:                 Backlight
+  // 27    1  0x3C                 Backlight
   this->publish_state_(this->dim_backlight_sensor_, (float) data[27]);
 
-  // 0x00 0x00 0x00 0x00 0x00 0x00: Unknown
-  // 0x4E:                 Checksum
+  // 28    7  0x00 0x00 0x00 0x00 0x00 0x00 0x00  Unknown
+  // 35    1  0x4E                 Checksum
 }
 
 void AtorchDL24::publish_state_(binary_sensor::BinarySensor *binary_sensor, const bool &state) {

--- a/components/atorch_dl24/atorch_dl24.cpp
+++ b/components/atorch_dl24/atorch_dl24.cpp
@@ -295,7 +295,8 @@ void AtorchDL24::decode_ac_and_dc_(const uint8_t *data, uint16_t length) {
   //
   // Byte Len Payload              Description
   //  0    2  0xFF 0x55            Magic header
-  //  2    1  0x01                 Message type           0x01: Report (32 byte), 0x02: Reply (4 byte), 0x11: Command (6 byte)
+  //  2    1  0x01                 Message type           0x01: Report (32 byte), 0x02: Reply (4 byte),
+  //                                                      0x11: Command (6 byte)
   //  3    1  0x02                 Device type            0x01: AC meter, 0x02: DC meter, 0x03: USB meter
   //  4    3  0x00 0x00 0x20       Voltage                32 * 0.1 = 3.2 V
   float voltage = dl24_get_24bit(4) * 0.1f;
@@ -370,7 +371,8 @@ void AtorchDL24::decode_usb_(const uint8_t *data, uint16_t length) {
   //
   // Byte Len Payload              Description
   //  0    2  0xFF 0x55            Magic header
-  //  2    1  0x01                 Message type           0x01: Report (32 byte), 0x02: Reply (4 byte), 0x11: Command (6 byte)
+  //  2    1  0x01                 Message type           0x01: Report (32 byte), 0x02: Reply (4 byte),
+  //                                                      0x11: Command (6 byte)
   //  3    1  0x03                 Device type            0x01: AC meter, 0x02: DC meter, 0x03: USB meter
   //  4    3  0x00 0x01 0xF3       Voltage                499 * 0.01 = 4.99 V
   float voltage = dl24_get_24bit(4) * 0.01f;

--- a/docs/protocol-design.md
+++ b/docs/protocol-design.md
@@ -91,7 +91,7 @@ Device broadcast name: `UD18-BLE`, `AT24-BLE`, etc `*-BLE`
 > [packet-meter-usb.spec.ts](../src/service/atorch-packet/packet-meter-usb.spec.ts)
 
 | Offset | Field       | Block size | Note                                |
-| -----: | ----------- | ---------- | ----------------------------------- |
+| -----: | ----------- |------------|-------------------------------------|
 |   `03` | Device Type | 1 byte     | `03` [Device Type](#type-indicator) |
 |   `04` | Voltage     | 3 byte     | 24 bit BE (divide by 100)           |
 |   `07` | Amp         | 3 byte     | 24 bit BE (divide by 100)           |
@@ -99,7 +99,7 @@ Device broadcast name: `UD18-BLE`, `AT24-BLE`, etc `*-BLE`
 |   `0D` | W·h         | 4 byte     | 32 bit BE (divide by 100)           |
 |   `11` | USB D-      | 2 byte     | 16 bit BE (divide by 100)           |
 |   `13` | USB D+      | 2 byte     | 16 bit BE (divide by 100)           |
-|   `15` | Temperature | 3 byte     | 24 bit BE                           |
+|   `15` | Temperature | 2 byte     | 16 bit BE                           |
 |   `17` | Hour        | 2 byte     | 16 bit BE                           |
 |   `19` | Minute      | 1 byte     |                                     |
 |   `1A` | Second      | 1 byte     |                                     |

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,5 @@
+# Gitignore settings for ESPHome
+# This is an example and may include too much for your use-case.
+# You can modify this file to suit your needs.
+/.esphome/
+/secrets.yaml

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,5 +1,0 @@
-# Gitignore settings for ESPHome
-# This is an example and may include too much for your use-case.
-# You can modify this file to suit your needs.
-/.esphome/
-/secrets.yaml

--- a/tests/esp32-atorch-j7-c-faker.yaml
+++ b/tests/esp32-atorch-j7-c-faker.yaml
@@ -1,0 +1,19 @@
+<<: !include esp32-atorch-j7-c.yaml
+
+atorch_dl24:
+  - id: atorch0
+    ble_client_id: ble_client0
+    check_crc: false
+    # The meter publishes a status report per second via BLE notification. If you don't like this update interval
+    # you can use this setting to throttle the sensor updates by skipping some status reports.
+    throttle: 0s
+
+interval:
+  - interval: 10s
+    then:
+      - lambda: |-
+          const uint8_t frame[36] = {
+            0xFF, 0x55, 0x01, 0x03, 0x00, 0x07, 0xEF, 0x00, 0x00, 0x23, 0x00, 0x01, 0x5A, 0x00, 0x00, 0x02, 0xBF, 0x00,
+            0x09, 0x00, 0x09, 0x00, 0x1F, 0x00, 0x00, 0x26, 0x00, 0x3C, 0x0D, 0xAC, 0x01, 0x22, 0x03, 0x20, 0x00, 0x0D
+          };
+          id(atorch0).decode(frame, sizeof(frame));

--- a/tests/esp32-atorch-j7-c.yaml
+++ b/tests/esp32-atorch-j7-c.yaml
@@ -16,7 +16,6 @@ esp32:
   board: wemos_d1_mini32
   framework:
     type: esp-idf
-    version: latest
 
 external_components:
   - source: ${external_components_source}

--- a/tests/esp32-atorch-j7-c.yaml
+++ b/tests/esp32-atorch-j7-c.yaml
@@ -1,0 +1,116 @@
+substitutions:
+  name: atorch-usb-meter
+  external_components_source: github://syssi/esphome-atorch-dl24@main
+  dl24_mac_address: !secret dl24_mac_address
+  project_version: 1.2.0
+  device_description: "Monitor and control a Atorch meter via bluetooth"
+
+esphome:
+  name: ${name}
+  comment: ${device_description}
+  project:
+    name: "syssi.esphome-atorch-dl24"
+    version: ${project_version}
+
+esp32:
+  board: wemos_d1_mini32
+  framework:
+    type: esp-idf
+    version: latest
+
+external_components:
+  - source: ${external_components_source}
+    refresh: 0s
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+ota:
+logger:
+
+mqtt:
+  broker: !secret mqtt_host
+  username: !secret mqtt_username
+  password: !secret mqtt_password
+  id: mqtt_client
+
+esp32_ble_tracker:
+
+ble_client:
+  - mac_address: ${dl24_mac_address}
+    id: ble_client0
+
+atorch_dl24:
+  - id: atorch0
+    ble_client_id: ble_client0
+    check_crc: true
+    # The meter publishes a status report per second via BLE notification. If you don't like this update interval
+    # you can use this setting to throttle the sensor updates by skipping some status reports.
+    throttle: 0s
+
+binary_sensor:
+  - platform: atorch_dl24
+    atorch_dl24_id: atorch0
+    running:
+      name: "${name} running"
+
+sensor:
+  - platform: atorch_dl24
+    atorch_dl24_id: atorch0
+    voltage:
+      name: "${name} voltage"
+    current:
+      name: "${name} current"
+    power:
+      name: "${name} power"
+    capacity:
+      name: "${name} capacity"
+    energy:
+      name: "${name} energy"
+    temperature:
+      name: "${name} temperature"
+    dim_backlight:
+      name: "${name} dim backlight"
+    running:
+      name: "${name} running"
+    usb_data_minus:
+      name: "${name} usb data minus"
+    usb_data_plus:
+      name: "${name} usb data plus"
+    runtime:
+      name: "${name} runtime"
+
+text_sensor:
+  - platform: atorch_dl24
+    atorch_dl24_id: atorch0
+    runtime_formatted:
+      name: "${name} runtime formatted"
+
+# If you use `mqtt` you can control a button if you publish the message "PRESS". The topic depends on
+# the name of your ESPHome node and the name of the button entity:
+#
+# mosquitto_pub -t 'atorch-usb-meter/button/atorch-usb-meter_reset_energy/command' -m 'PRESS'
+# mosquitto_pub -t 'atorch-usb-meter/button/atorch-usb-meter_reset_capacity/command' -m 'PRESS'
+# mosquitto_pub -t 'atorch-usb-meter/button/atorch-usb-meter_reset_runtime/command' -m 'PRESS'
+# mosquitto_pub -t 'atorch-usb-meter/button/atorch-usb-meter_reset_all/command' -m 'PRESS'
+# ...
+button:
+  - platform: atorch_dl24
+    atorch_dl24_id: atorch0
+    reset_energy:
+      name: "${name} reset energy"
+    reset_capacity:
+      name: "${name} reset capacity"
+    reset_runtime:
+      name: "${name} reset runtime"
+    reset_all:
+      name: "${name} reset all"
+    setup:
+      name: "${name} setup"
+    enter:
+      name: "${name} enter"
+    usb_plus:
+      name: "${name} plus"
+    usb_minus:
+      name: "${name} minus"

--- a/tests/esp32-atorch-j7-c.yaml
+++ b/tests/esp32-atorch-j7-c.yaml
@@ -43,7 +43,7 @@ ble_client:
 atorch_dl24:
   - id: atorch0
     ble_client_id: ble_client0
-    check_crc: true
+    check_crc: false
     # The meter publishes a status report per second via BLE notification. If you don't like this update interval
     # you can use this setting to throttle the sensor updates by skipping some status reports.
     throttle: 0s


### PR DESCRIPTION
```
[14:11:01][I][atorch_dl24:255]: Status report received
[14:11:01][D][sensor:127]: 'atorch-usb-meter voltage': Sending state 20.31000 V with 2 decimals of accuracy
[14:11:01][D][sensor:127]: 'atorch-usb-meter current': Sending state 0.35000 A with 3 decimals of accuracy
[14:11:01][D][sensor:127]: 'atorch-usb-meter power': Sending state 7.10850 W with 4 decimals of accuracy
[14:11:01][D][sensor:127]: 'atorch-usb-meter capacity': Sending state 0.34600 Ah with 3 decimals of accuracy
[14:11:01][D][sensor:127]: 'atorch-usb-meter energy': Sending state 7.03000 Wh with 0 decimals of accuracy
[14:11:01][D][sensor:127]: 'atorch-usb-meter usb data minus': Sending state 0.09000 V with 2 decimals of accuracy
[14:11:01][D][sensor:127]: 'atorch-usb-meter usb data plus': Sending state 0.09000 V with 2 decimals of accuracy
[14:11:01][D][sensor:127]: 'atorch-usb-meter temperature': Sending state 7936.00000 °C with 0 decimals of accuracy
[14:11:01][D][sensor:127]: 'atorch-usb-meter runtime': Sending state 2280.00000 s with 0 decimals of accuracy
[14:11:01][D][text_sensor:067]: 'atorch-usb-meter runtime formatted': Sending state '38m '
[14:11:01][D][sensor:127]: 'atorch-usb-meter running': Sending state 0.00000  with 0 decimals of accuracy
[14:11:01][D][binary_sensor:036]: 'atorch-usb-meter running': Sending state OFF
[14:11:01][D][sensor:127]: 'atorch-usb-meter dim backlight': Sending state 60.00000 s with 0 decimals of accuracy
```

https://github.com/adlerweb/J7-C_UC96_BLE_Logger
