### PR TITLE
Drop deprecated `running` sensor

### DIFF
--- a/components/atorch_dl24/atorch_dl24.cpp
+++ b/components/atorch_dl24/atorch_dl24.cpp
@@ -70,7 +70,6 @@ void AtorchDL24::dump_config() {
   LOG_SENSOR(" ", "Energy", this->energy_sensor_);
   LOG_SENSOR(" ", "Temperature", this->temperature_sensor_);
   LOG_SENSOR(" ", "Dim Backlight", this->dim_backlight_sensor_);
-  LOG_SENSOR(" ", "Running", this->running_sensor_);
   LOG_BINARY_SENSOR(" ", "Running", this->running_binary_sensor_);
   LOG_SENSOR(" ", "USB Data Minus", this->usb_data_minus_sensor_);
   LOG_SENSOR(" ", "USB Data Plus", this->usb_data_plus_sensor_);
@@ -97,7 +96,6 @@ void AtorchDL24::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t g
       this->publish_state_(this->energy_sensor_, NAN);
       this->publish_state_(this->temperature_sensor_, NAN);
       this->publish_state_(this->dim_backlight_sensor_, NAN);
-      this->publish_state_(this->running_sensor_, NAN);
       this->publish_state_(this->runtime_sensor_, NAN);
       this->publish_state_(this->runtime_formatted_text_sensor_, "");
 
@@ -338,7 +336,6 @@ void AtorchDL24::decode_ac_and_dc_(const uint8_t *data, uint16_t length) {
 
   if (previous_value_ != 61) {
     bool running = previous_value_ != data[29];
-    this->publish_state_(this->running_sensor_, (float) running);  // @DEPRECATED
     this->publish_state_(this->running_binary_sensor_, running);
   }
   previous_value_ = data[29];
@@ -409,7 +406,6 @@ void AtorchDL24::decode_usb_(const uint8_t *data, uint16_t length) {
 
   if (previous_value_ != 61) {
     bool running = previous_value_ != data[26];
-    this->publish_state_(this->running_sensor_, (float) running);  // @DEPRECATED
     this->publish_state_(this->running_binary_sensor_, running);
   }
   previous_value_ = data[26];

--- a/components/atorch_dl24/atorch_dl24.h
+++ b/components/atorch_dl24/atorch_dl24.h
@@ -37,7 +37,6 @@ class AtorchDL24 : public esphome::ble_client::BLEClientNode, public Component {
   void set_energy_sensor(sensor::Sensor *energy_sensor) { energy_sensor_ = energy_sensor; }
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }
   void set_dim_backlight_sensor(sensor::Sensor *dim_backlight_sensor) { dim_backlight_sensor_ = dim_backlight_sensor; }
-  void set_running_sensor(sensor::Sensor *running_sensor) { running_sensor_ = running_sensor; }
   void set_usb_data_minus_sensor(sensor::Sensor *usb_data_minus_sensor) {
     usb_data_minus_sensor_ = usb_data_minus_sensor;
   }
@@ -87,7 +86,6 @@ class AtorchDL24 : public esphome::ble_client::BLEClientNode, public Component {
   sensor::Sensor *energy_sensor_{nullptr};
   sensor::Sensor *temperature_sensor_{nullptr};
   sensor::Sensor *dim_backlight_sensor_{nullptr};
-  sensor::Sensor *running_sensor_{nullptr};
   sensor::Sensor *usb_data_minus_sensor_{nullptr};
   sensor::Sensor *usb_data_plus_sensor_{nullptr};
   sensor::Sensor *price_per_kwh_sensor_{nullptr};

--- a/components/atorch_dl24/sensor.py
+++ b/components/atorch_dl24/sensor.py
@@ -41,7 +41,6 @@ DEPENDENCIES = ["atorch_dl24"]
 CODEOWNERS = ["@syssi"]
 
 CONF_DIM_BACKLIGHT = "dim_backlight"
-CONF_RUNNING = "running"
 
 CONF_USB_DATA_MINUS = "usb_data_minus"
 CONF_USB_DATA_PLUS = "usb_data_plus"
@@ -51,7 +50,6 @@ CONF_RUNTIME = "runtime"
 
 UNIT_AMPERE_HOURS = "Ah"
 ICON_CAPACITY = "mdi:battery-medium"
-ICON_RUNNING = "mdi:power"
 
 SENSORS = [
     CONF_VOLTAGE,
@@ -61,7 +59,6 @@ SENSORS = [
     CONF_ENERGY,
     CONF_TEMPERATURE,
     CONF_DIM_BACKLIGHT,
-    CONF_RUNNING,
     CONF_USB_DATA_MINUS,
     CONF_USB_DATA_PLUS,
     CONF_PRICE_PER_KWH,
@@ -119,13 +116,6 @@ CONFIG_SCHEMA = ATORCH_DL24_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_DIM_BACKLIGHT): sensor.sensor_schema(
             unit_of_measurement=UNIT_SECOND,
             icon=ICON_TIMER,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_RUNNING): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon=ICON_RUNNING,
             accuracy_decimals=0,
             device_class=DEVICE_CLASS_EMPTY,
             state_class=STATE_CLASS_MEASUREMENT,

--- a/esp32-ac-meter-example.yaml
+++ b/esp32-ac-meter-example.yaml
@@ -2,7 +2,7 @@ substitutions:
   name: atorch-ac-meter
   external_components_source: github://syssi/esphome-atorch-dl24@main
   dl24_mac_address: !secret dl24_mac_address
-  project_version: 1.3.0
+  project_version: 2.0.0
   device_description: "Monitor and control a Atorch meter via bluetooth"
 
 esphome:

--- a/esp32-dc-meter-example-advanced-multiple-devices.yaml
+++ b/esp32-dc-meter-example-advanced-multiple-devices.yaml
@@ -5,7 +5,7 @@ substitutions:
   external_components_source: github://syssi/esphome-atorch-dl24@main
   dl24_mac_address0: !secret dl24_mac_address0
   dl24_mac_address1: !secret dl24_mac_address1
-  project_version: 1.3.0
+  project_version: 2.0.0
   device_description: "Monitor and control two Atorch meters via bluetooth"
 
 esphome:
@@ -94,8 +94,6 @@ sensor:
       name: "${device0} temperature"
     dim_backlight:
       name: "${device0} dim backlight"
-    running:
-      name: "${device0} running"
     runtime:
       name: "${device0} runtime"
 
@@ -115,8 +113,6 @@ sensor:
       name: "${device1} temperature"
     dim_backlight:
       name: "${device1} dim backlight"
-    running:
-      name: "${device1} running"
     runtime:
       name: "${device1} runtime"
 

--- a/esp32-dc-meter-example.yaml
+++ b/esp32-dc-meter-example.yaml
@@ -2,7 +2,7 @@ substitutions:
   name: atorch-dc-meter
   external_components_source: github://syssi/esphome-atorch-dl24@main
   dl24_mac_address: !secret dl24_mac_address
-  project_version: 1.3.0
+  project_version: 2.0.0
   device_description: "Monitor and control a Atorch meter via bluetooth"
 
 esphome:
@@ -77,8 +77,6 @@ sensor:
       name: "${name} temperature"
     dim_backlight:
       name: "${name} dim backlight"
-    running:
-      name: "${name} running"
     runtime:
       name: "${name} runtime"
 

--- a/esp32-usb-meter-example.yaml
+++ b/esp32-usb-meter-example.yaml
@@ -2,7 +2,7 @@ substitutions:
   name: atorch-usb-meter
   external_components_source: github://syssi/esphome-atorch-dl24@main
   dl24_mac_address: !secret dl24_mac_address
-  project_version: 1.3.0
+  project_version: 2.0.0
   device_description: "Monitor and control a Atorch meter via bluetooth"
 
 esphome:
@@ -77,8 +77,6 @@ sensor:
       name: "${name} temperature"
     dim_backlight:
       name: "${name} dim backlight"
-    running:
-      name: "${name} running"
     usb_data_minus:
       name: "${name} usb data minus"
     usb_data_plus:

--- a/tests/esp32-atorch-dt3010.yaml
+++ b/tests/esp32-atorch-dt3010.yaml
@@ -5,7 +5,7 @@ substitutions:
   name: atorch-dc-meter
   external_components_source: github://syssi/esphome-atorch-dl24@main
   dl24_mac_address: !secret dl24_mac_address
-  project_version: 1.3.0
+  project_version: 2.0.0
   device_description: "Monitor and control a Atorch meter via bluetooth"
 
 esphome:

--- a/tests/esp32-atorch-j7-c.yaml
+++ b/tests/esp32-atorch-j7-c.yaml
@@ -2,7 +2,7 @@ substitutions:
   name: atorch-usb-meter
   external_components_source: github://syssi/esphome-atorch-dl24@main
   dl24_mac_address: !secret dl24_mac_address
-  project_version: 1.3.0
+  project_version: 2.0.0
   device_description: "Monitor and control a Atorch meter via bluetooth"
 
 esphome:
@@ -77,8 +77,6 @@ sensor:
       name: "${name} temperature"
     dim_backlight:
       name: "${name} dim backlight"
-    running:
-      name: "${name} running"
     usb_data_minus:
       name: "${name} usb data minus"
     usb_data_plus:


### PR DESCRIPTION
Please remove the sensor entity `running` from your YAML. The binary sensor `running` should be used instead.