### PR TITLE
Explicitly initialize all pointer members to nullptr

### DIFF
--- a/components/atorch_dl24/atorch_dl24.h
+++ b/components/atorch_dl24/atorch_dl24.h
@@ -91,7 +91,7 @@ class AtorchDL24 : public esphome::ble_client::BLEClientNode, public Component {
     return std::string(buf, len);
   }
 
-  binary_sensor::BinarySensor *running_binary_sensor_;
+  binary_sensor::BinarySensor *running_binary_sensor_{nullptr};
 
   sensor::Sensor *voltage_sensor_{nullptr};
   sensor::Sensor *current_sensor_{nullptr};
@@ -107,7 +107,7 @@ class AtorchDL24 : public esphome::ble_client::BLEClientNode, public Component {
   sensor::Sensor *power_factor_sensor_{nullptr};
   sensor::Sensor *runtime_sensor_{nullptr};
 
-  text_sensor::TextSensor *runtime_formatted_text_sensor_;
+  text_sensor::TextSensor *runtime_formatted_text_sensor_{nullptr};
 
   bool check_crc_;
 


### PR DESCRIPTION
## Summary
- Add `{nullptr}` in-class initializer to all raw pointer members in component header files that previously had no initializer
- Aligns with ESPHome core style: every component in the ESPHome core uses `{nullptr}` for pointer members — no uninitialized pointer exists in the core codebase
- While ESPHome instantiates components via `new T()` (value-initializes to zero), explicit `{nullptr}` makes the intent unambiguous and matches the upstream convention