### PR TITLE
Use new_text_sensor() instead of deprecated register_text_sensor

### DIFF
--- a/components/atorch_dl24/text_sensor.py
+++ b/components/atorch_dl24/text_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, ICON_TIMELAPSE
+from esphome.const import ICON_TIMELAPSE
 
 from . import ATORCH_DL24_COMPONENT_SCHEMA, CONF_ATORCH_DL24_ID
 
@@ -29,6 +29,5 @@ async def to_code(config):
     for key in TEXT_SENSORS:
         if key in config:
             conf = config[key]
-            sens = cg.new_Pvariable(conf[CONF_ID])
-            await text_sensor.register_text_sensor(sens, conf)
+            sens = await text_sensor.new_text_sensor(conf)
             cg.add(getattr(hub, f"set_{key}_text_sensor")(sens))


### PR DESCRIPTION
## Summary
- Replace `cg.new_Pvariable(conf[CONF_ID])` + `await text_sensor.register_text_sensor(sens, conf)` with the modern `await text_sensor.new_text_sensor(conf)`
- Remove now-unused `CONF_ID` imports where applicable
- Aligns with the pattern already used in `sensor.py` via `await sensor.new_sensor(conf)`