### PR TITLE
Use new_* API instead of deprecated register_* functions

### DIFF
--- a/components/atorch_dl24/binary_sensor.py
+++ b/components/atorch_dl24/binary_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, ENTITY_CATEGORY_DIAGNOSTIC
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import ATORCH_DL24_COMPONENT_SCHEMA, CONF_ATORCH_DL24_ID
 
@@ -30,6 +30,5 @@ async def to_code(config):
     for key in BINARY_SENSORS:
         if key in config:
             conf = config[key]
-            sens = cg.new_Pvariable(conf[CONF_ID])
-            await binary_sensor.register_binary_sensor(sens, conf)
+            sens = await binary_sensor.new_binary_sensor(conf)
             cg.add(getattr(hub, f"set_{key}_binary_sensor")(sens))

--- a/components/atorch_dl24/button/__init__.py
+++ b/components/atorch_dl24/button/__init__.py
@@ -1,7 +1,6 @@
 import esphome.codegen as cg
 from esphome.components import button
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
 
 from .. import ATORCH_DL24_COMPONENT_SCHEMA, CONF_ATORCH_DL24_ID, atorch_dl24_ns
 
@@ -88,8 +87,7 @@ async def to_code(config):
     for key, address in BUTTONS.items():
         if key in config:
             conf = config[key]
-            var = cg.new_Pvariable(conf[CONF_ID])
+            var = await button.new_button(conf)
             await cg.register_component(var, conf)
-            await button.register_button(var, conf)
             cg.add(var.set_parent(hub))
             cg.add(var.set_holding_register(address))


### PR DESCRIPTION
## Summary

- Replace deprecated `register_binary_sensor` and `register_button` calls with the new `new_binary_sensor` and `new_button` API
- Remove now-unnecessary `CONF_ID` imports and `cg.new_Pvariable` calls
- Align with upstream migration as done in [syssi/esphome-jk-bms#912](https://github.com/syssi/esphome-jk-bms/pull/912)