### PR TITLE
Fix text_sensor_schema positional arg

### DIFF
--- a/components/atorch_dl24/text_sensor.py
+++ b/components/atorch_dl24/text_sensor.py
@@ -18,7 +18,7 @@ TEXT_SENSORS = [
 CONFIG_SCHEMA = ATORCH_DL24_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_RUNTIME_FORMATTED): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_TIMELAPSE
+            icon=ICON_TIMELAPSE
         ),
     }
 )


### PR DESCRIPTION
## Summary

- Remove positional `text_sensor.TextSensor` argument from `text_sensor_schema(...)` call (T1)

Follows the pattern established in `esphome-tianpower-bms`.