### PR TITLE
Remove redundant name substitution prefix from entity names

### DIFF
--- a/esp32-ac-meter-example.yaml
+++ b/esp32-ac-meter-example.yaml
@@ -7,6 +7,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-atorch-dl24"

--- a/esp32-ac-meter-example.yaml
+++ b/esp32-ac-meter-example.yaml
@@ -65,7 +65,7 @@ binary_sensor:
   - platform: atorch_dl24
     atorch_dl24_id: atorch0
     running:
-      name: "${name} running"
+      name: "running"
 
 # If you use `mqtt` you can control a button if you publish the message "PRESS". The topic depends on
 # the name of your ESPHome node and the name of the button entity:
@@ -79,56 +79,56 @@ button:
   - platform: atorch_dl24
     atorch_dl24_id: atorch0
     reset_energy:
-      name: "${name} reset energy"
+      name: "reset energy"
     reset_capacity:
-      name: "${name} reset capacity"
+      name: "reset capacity"
     reset_runtime:
-      name: "${name} reset runtime"
+      name: "reset runtime"
     reset_all:
-      name: "${name} reset all"
+      name: "reset all"
     plus:
-      name: "${name} plus"
+      name: "plus"
     minus:
-      name: "${name} minus"
+      name: "minus"
     setup:
-      name: "${name} setup"
+      name: "setup"
     enter:
-      name: "${name} enter"
+      name: "enter"
 
 sensor:
   - platform: atorch_dl24
     atorch_dl24_id: atorch0
     voltage:
-      name: "${name} voltage"
+      name: "voltage"
     current:
-      name: "${name} current"
+      name: "current"
     power:
-      name: "${name} power"
+      name: "power"
     capacity:
-      name: "${name} capacity"
+      name: "capacity"
     energy:
-      name: "${name} energy"
+      name: "energy"
     temperature:
-      name: "${name} temperature"
+      name: "temperature"
     dim_backlight:
-      name: "${name} dim backlight"
+      name: "dim backlight"
     frequency:
-      name: "${name} frequency"
+      name: "frequency"
     power_factor:
-      name: "${name} power_factor"
+      name: "power_factor"
     price_per_kwh:
-      name: "${name} price per kwh"
+      name: "price per kwh"
     runtime:
-      name: "${name} runtime"
+      name: "runtime"
 
 switch:
   - platform: ble_client
     ble_client_id: client0
-    name: "${name} enable bluetooth connection"
+    name: "enable bluetooth connection"
     id: ble_client_switch0
 
 text_sensor:
   - platform: atorch_dl24
     atorch_dl24_id: atorch0
     runtime_formatted:
-      name: "${name} runtime formatted"
+      name: "runtime formatted"

--- a/esp32-ble-scanner.yaml
+++ b/esp32-ble-scanner.yaml
@@ -5,6 +5,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-atorch-dl24"

--- a/esp32-dc-meter-example-advanced-multiple-devices.yaml
+++ b/esp32-dc-meter-example-advanced-multiple-devices.yaml
@@ -10,6 +10,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-atorch-dl24"

--- a/esp32-dc-meter-example.yaml
+++ b/esp32-dc-meter-example.yaml
@@ -7,6 +7,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-atorch-dl24"

--- a/esp32-dc-meter-example.yaml
+++ b/esp32-dc-meter-example.yaml
@@ -65,7 +65,7 @@ binary_sensor:
   - platform: atorch_dl24
     atorch_dl24_id: atorch0
     running:
-      name: "${name} running"
+      name: "running"
 
 # If you use `mqtt` you can control a button if you publish the message "PRESS". The topic depends on
 # the name of your ESPHome node and the name of the button entity:
@@ -79,50 +79,50 @@ button:
   - platform: atorch_dl24
     atorch_dl24_id: atorch0
     reset_energy:
-      name: "${name} reset energy"
+      name: "reset energy"
     reset_capacity:
-      name: "${name} reset capacity"
+      name: "reset capacity"
     reset_runtime:
-      name: "${name} reset runtime"
+      name: "reset runtime"
     reset_all:
-      name: "${name} reset all"
+      name: "reset all"
     usb_plus:
-      name: "${name} plus"
+      name: "plus"
     usb_minus:
-      name: "${name} minus"
+      name: "minus"
     setup:
-      name: "${name} setup"
+      name: "setup"
     enter:
-      name: "${name} enter"
+      name: "enter"
 
 sensor:
   - platform: atorch_dl24
     atorch_dl24_id: atorch0
     voltage:
-      name: "${name} voltage"
+      name: "voltage"
     current:
-      name: "${name} current"
+      name: "current"
     power:
-      name: "${name} power"
+      name: "power"
     capacity:
-      name: "${name} capacity"
+      name: "capacity"
     energy:
-      name: "${name} energy"
+      name: "energy"
     temperature:
-      name: "${name} temperature"
+      name: "temperature"
     dim_backlight:
-      name: "${name} dim backlight"
+      name: "dim backlight"
     runtime:
-      name: "${name} runtime"
+      name: "runtime"
 
 switch:
   - platform: ble_client
     ble_client_id: client0
-    name: "${name} enable bluetooth connection"
+    name: "enable bluetooth connection"
     id: ble_client_switch0
 
 text_sensor:
   - platform: atorch_dl24
     atorch_dl24_id: atorch0
     runtime_formatted:
-      name: "${name} runtime formatted"
+      name: "runtime formatted"

--- a/esp32-usb-meter-example.yaml
+++ b/esp32-usb-meter-example.yaml
@@ -7,6 +7,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-atorch-dl24"

--- a/esp32-usb-meter-example.yaml
+++ b/esp32-usb-meter-example.yaml
@@ -65,7 +65,7 @@ binary_sensor:
   - platform: atorch_dl24
     atorch_dl24_id: atorch0
     running:
-      name: "${name} running"
+      name: "running"
 
 # If you use `mqtt` you can control a button if you publish the message "PRESS". The topic depends on
 # the name of your ESPHome node and the name of the button entity:
@@ -79,54 +79,54 @@ button:
   - platform: atorch_dl24
     atorch_dl24_id: atorch0
     reset_energy:
-      name: "${name} reset energy"
+      name: "reset energy"
     reset_capacity:
-      name: "${name} reset capacity"
+      name: "reset capacity"
     reset_runtime:
-      name: "${name} reset runtime"
+      name: "reset runtime"
     reset_all:
-      name: "${name} reset all"
+      name: "reset all"
     setup:
-      name: "${name} setup"
+      name: "setup"
     enter:
-      name: "${name} enter"
+      name: "enter"
     usb_plus:
-      name: "${name} plus"
+      name: "plus"
     usb_minus:
-      name: "${name} minus"
+      name: "minus"
 
 sensor:
   - platform: atorch_dl24
     atorch_dl24_id: atorch0
     voltage:
-      name: "${name} voltage"
+      name: "voltage"
     current:
-      name: "${name} current"
+      name: "current"
     power:
-      name: "${name} power"
+      name: "power"
     capacity:
-      name: "${name} capacity"
+      name: "capacity"
     energy:
-      name: "${name} energy"
+      name: "energy"
     temperature:
-      name: "${name} temperature"
+      name: "temperature"
     dim_backlight:
-      name: "${name} dim backlight"
+      name: "dim backlight"
     usb_data_minus:
-      name: "${name} usb data minus"
+      name: "usb data minus"
     usb_data_plus:
-      name: "${name} usb data plus"
+      name: "usb data plus"
     runtime:
-      name: "${name} runtime"
+      name: "runtime"
 
 switch:
   - platform: ble_client
     ble_client_id: client0
-    name: "${name} enable bluetooth connection"
+    name: "enable bluetooth connection"
     id: ble_client_switch0
 
 text_sensor:
   - platform: atorch_dl24
     atorch_dl24_id: atorch0
     runtime_formatted:
-      name: "${name} runtime formatted"
+      name: "runtime formatted"

--- a/tests/esp32-atorch-dt3010.yaml
+++ b/tests/esp32-atorch-dt3010.yaml
@@ -63,25 +63,25 @@ sensor:
   - platform: atorch_dl24
     atorch_dl24_id: atorch0
     voltage:
-      name: "${name} voltage"
+      name: "voltage"
     current:
-      name: "${name} current"
+      name: "current"
     power:
-      name: "${name} power"
+      name: "power"
     capacity:
-      name: "${name} capacity"
+      name: "capacity"
     energy:
-      name: "${name} energy"
+      name: "energy"
     temperature:
-      name: "${name} temperature"
+      name: "temperature"
     dim_backlight:
-      name: "${name} dim backlight"
+      name: "dim backlight"
 
 text_sensor:
   - platform: atorch_dl24
     atorch_dl24_id: atorch0
     runtime_formatted:
-      name: "${name} runtime formatted"
+      name: "runtime formatted"
 
 # If you use `mqtt` you can control a button if you publish the message "PRESS". The topic depends on
 # the name of your ESPHome node and the name of the button entity:
@@ -95,18 +95,18 @@ button:
   - platform: atorch_dl24
     atorch_dl24_id: atorch0
     reset_energy:
-      name: "${name} reset energy"
+      name: "reset energy"
     reset_capacity:
-      name: "${name} reset capacity"
+      name: "reset capacity"
     reset_runtime:
-      name: "${name} reset runtime"
+      name: "reset runtime"
     reset_all:
-      name: "${name} reset all"
+      name: "reset all"
     plus:
-      name: "${name} plus"
+      name: "plus"
     minus:
-      name: "${name} minus"
+      name: "minus"
     setup:
-      name: "${name} setup"
+      name: "setup"
     enter:
-      name: "${name} enter"
+      name: "enter"

--- a/tests/esp32-atorch-dt3010.yaml
+++ b/tests/esp32-atorch-dt3010.yaml
@@ -10,6 +10,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   min_version: 2024.6.0
   project:

--- a/tests/esp32-atorch-j7-c.yaml
+++ b/tests/esp32-atorch-j7-c.yaml
@@ -60,37 +60,37 @@ binary_sensor:
   - platform: atorch_dl24
     atorch_dl24_id: atorch0
     running:
-      name: "${name} running"
+      name: "running"
 
 sensor:
   - platform: atorch_dl24
     atorch_dl24_id: atorch0
     voltage:
-      name: "${name} voltage"
+      name: "voltage"
     current:
-      name: "${name} current"
+      name: "current"
     power:
-      name: "${name} power"
+      name: "power"
     capacity:
-      name: "${name} capacity"
+      name: "capacity"
     energy:
-      name: "${name} energy"
+      name: "energy"
     temperature:
-      name: "${name} temperature"
+      name: "temperature"
     dim_backlight:
-      name: "${name} dim backlight"
+      name: "dim backlight"
     usb_data_minus:
-      name: "${name} usb data minus"
+      name: "usb data minus"
     usb_data_plus:
-      name: "${name} usb data plus"
+      name: "usb data plus"
     runtime:
-      name: "${name} runtime"
+      name: "runtime"
 
 text_sensor:
   - platform: atorch_dl24
     atorch_dl24_id: atorch0
     runtime_formatted:
-      name: "${name} runtime formatted"
+      name: "runtime formatted"
 
 # If you use `mqtt` you can control a button if you publish the message "PRESS". The topic depends on
 # the name of your ESPHome node and the name of the button entity:
@@ -104,18 +104,18 @@ button:
   - platform: atorch_dl24
     atorch_dl24_id: atorch0
     reset_energy:
-      name: "${name} reset energy"
+      name: "reset energy"
     reset_capacity:
-      name: "${name} reset capacity"
+      name: "reset capacity"
     reset_runtime:
-      name: "${name} reset runtime"
+      name: "reset runtime"
     reset_all:
-      name: "${name} reset all"
+      name: "reset all"
     setup:
-      name: "${name} setup"
+      name: "setup"
     enter:
-      name: "${name} enter"
+      name: "enter"
     usb_plus:
-      name: "${name} plus"
+      name: "plus"
     usb_minus:
-      name: "${name} minus"
+      name: "minus"

--- a/tests/esp32-atorch-j7-c.yaml
+++ b/tests/esp32-atorch-j7-c.yaml
@@ -7,6 +7,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   min_version: 2024.6.0
   project:

--- a/tests/esp32-atorch-s1.yaml
+++ b/tests/esp32-atorch-s1.yaml
@@ -60,39 +60,39 @@ binary_sensor:
   - platform: atorch_dl24
     atorch_dl24_id: atorch0
     running:
-      name: "${name} running"
+      name: "running"
 
 sensor:
   - platform: atorch_dl24
     atorch_dl24_id: atorch0
     voltage:
-      name: "${name} voltage"
+      name: "voltage"
     current:
-      name: "${name} current"
+      name: "current"
     power:
-      name: "${name} power"
+      name: "power"
     capacity:
-      name: "${name} capacity"
+      name: "capacity"
     energy:
-      name: "${name} energy"
+      name: "energy"
     temperature:
-      name: "${name} temperature"
+      name: "temperature"
     dim_backlight:
-      name: "${name} dim backlight"
+      name: "dim backlight"
     frequency:
-      name: "${name} frequency"
+      name: "frequency"
     power_factor:
-      name: "${name} power_factor"
+      name: "power_factor"
     price_per_kwh:
-      name: "${name} price per kwh"
+      name: "price per kwh"
     runtime:
-      name: "${name} runtime"
+      name: "runtime"
 
 text_sensor:
   - platform: atorch_dl24
     atorch_dl24_id: atorch0
     runtime_formatted:
-      name: "${name} runtime formatted"
+      name: "runtime formatted"
 
 # If you use `mqtt` you can control a button if you publish the message "PRESS". The topic depends on
 # the name of your ESPHome node and the name of the button entity:
@@ -106,18 +106,18 @@ button:
   - platform: atorch_dl24
     atorch_dl24_id: atorch0
     reset_energy:
-      name: "${name} reset energy"
+      name: "reset energy"
     reset_capacity:
-      name: "${name} reset capacity"
+      name: "reset capacity"
     reset_runtime:
-      name: "${name} reset runtime"
+      name: "reset runtime"
     reset_all:
-      name: "${name} reset all"
+      name: "reset all"
     plus:
-      name: "${name} plus"
+      name: "plus"
     minus:
-      name: "${name} minus"
+      name: "minus"
     setup:
-      name: "${name} setup"
+      name: "setup"
     enter:
-      name: "${name} enter"
+      name: "enter"

--- a/tests/esp32-atorch-s1.yaml
+++ b/tests/esp32-atorch-s1.yaml
@@ -7,6 +7,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   min_version: 2024.6.0
   project:

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -5,6 +5,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   min_version: 2025.6.0
 

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -49,4 +49,4 @@ sensor:
   - platform: atorch_dl24
     atorch_dl24_id: atorch0
     voltage:
-      name: "${name} voltage"
+      name: "voltage"


### PR DESCRIPTION
ESPHome's `friendly_name` automatically prefixes all entity names, making the `${name}` substitution in entity name strings redundant.