### PR TITLE
Add component schema tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -396,6 +396,30 @@ jobs:
         # yamllint disable-line rule:line-length
         if: always()
 
+  pytest:
+    name: Run pytest
+    runs-on: ubuntu-24.04
+    needs:
+      - bundle
+      - common
+    steps:
+      - name: Download prepared repository
+        uses: pyTooling/download-artifact@v4
+        with:
+          name: bundle
+          path: .
+
+      - name: Restore Python
+        uses: ./.github/actions/restore-python
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+          cache-key: ${{ needs.common.outputs.cache-key }}
+
+      - name: Run pytest
+        run: |
+          . venv/bin/activate
+          pytest tests/ -v
+
   esphome-config:
     name: Validate example configurations
     runs-on: ubuntu-24.04

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,15 @@ repos:
         args: [--persistent=n, components]
         pass_filenames: false
         additional_dependencies: [esphome]
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest
+        language: python
+        types: [python]
+        pass_filenames: false
+        additional_dependencies: [pytest, esphome]
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v13.0.1
     hooks:

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -1,0 +1,78 @@
+"""Schema structure tests for atorch_dl24 ESPHome component modules."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import components.atorch_dl24 as hub  # noqa: E402
+from components.atorch_dl24 import (  # noqa: E402
+    binary_sensor,
+    button,  # noqa: E402
+    sensor,
+    text_sensor,
+)
+
+
+class TestHubConstants:
+    def test_conf_atorch_dl24_id_defined(self):
+        assert hub.CONF_ATORCH_DL24_ID == "atorch_dl24_id"
+
+    def test_conf_check_crc_defined(self):
+        assert hub.CONF_CHECK_CRC == "check_crc"
+
+
+class TestSensorDefs:
+    def test_sensor_defs_completeness(self):
+        from esphome.const import (
+            CONF_CAPACITY,
+            CONF_CURRENT,
+            CONF_ENERGY,
+            CONF_FREQUENCY,
+            CONF_POWER,
+            CONF_POWER_FACTOR,
+            CONF_TEMPERATURE,
+            CONF_VOLTAGE,
+        )
+
+        assert CONF_VOLTAGE in sensor.SENSOR_DEFS
+        assert CONF_CURRENT in sensor.SENSOR_DEFS
+        assert CONF_POWER in sensor.SENSOR_DEFS
+        assert CONF_ENERGY in sensor.SENSOR_DEFS
+        assert CONF_TEMPERATURE in sensor.SENSOR_DEFS
+        assert CONF_CAPACITY in sensor.SENSOR_DEFS
+        assert CONF_FREQUENCY in sensor.SENSOR_DEFS
+        assert CONF_POWER_FACTOR in sensor.SENSOR_DEFS
+        assert sensor.CONF_RUNTIME in sensor.SENSOR_DEFS
+        assert len(sensor.SENSOR_DEFS) == 13
+
+
+class TestBinarySensorDefs:
+    def test_binary_sensor_defs_completeness(self):
+        assert binary_sensor.CONF_RUNNING in binary_sensor.BINARY_SENSOR_DEFS
+        assert len(binary_sensor.BINARY_SENSOR_DEFS) == 1
+
+
+class TestTextSensors:
+    def test_text_sensors_list(self):
+        assert text_sensor.CONF_RUNTIME_FORMATTED in text_sensor.TEXT_SENSORS
+        assert len(text_sensor.TEXT_SENSORS) == 1
+
+
+class TestButtonConstants:
+    def test_buttons_dict_completeness(self):
+        assert button.CONF_RESET_ENERGY in button.BUTTONS
+        assert button.CONF_RESET_CAPACITY in button.BUTTONS
+        assert button.CONF_RESET_RUNTIME in button.BUTTONS
+        assert button.CONF_RESET_ALL in button.BUTTONS
+        assert button.CONF_PLUS in button.BUTTONS
+        assert button.CONF_MINUS in button.BUTTONS
+        assert button.CONF_SETUP in button.BUTTONS
+        assert button.CONF_ENTER in button.BUTTONS
+        assert button.CONF_USB_PLUS in button.BUTTONS
+        assert button.CONF_USB_MINUS in button.BUTTONS
+        assert len(button.BUTTONS) == 10
+
+    def test_button_addresses_are_unique(self):
+        addresses = list(button.BUTTONS.values())
+        assert len(addresses) == len(set(addresses))


### PR DESCRIPTION
## Summary
- Add `tests/test_component_schemas.py` with schema structure tests for all component modules
- Add pytest hook to `.pre-commit-config.yaml`
- Add pytest job to CI workflow

## Test plan
- [x] All existing tests pass
- [x] New pytest job passes in CI