### PR TITLE
Add entity_category to all text sensor schemas

### DIFF
--- a/components/atorch_dl24/text_sensor.py
+++ b/components/atorch_dl24/text_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
-from esphome.const import ICON_TIMELAPSE
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC, ICON_TIMELAPSE
 
 from . import ATORCH_DL24_COMPONENT_SCHEMA, CONF_ATORCH_DL24_ID
 
@@ -18,7 +18,8 @@ TEXT_SENSORS = [
 CONFIG_SCHEMA = ATORCH_DL24_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_RUNTIME_FORMATTED): text_sensor.text_sensor_schema(
-            icon=ICON_TIMELAPSE
+            icon=ICON_TIMELAPSE,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
     }
 )


### PR DESCRIPTION
Text sensors were missing `entity_category=ENTITY_CATEGORY_DIAGNOSTIC`, which causes them to appear as regular state entities instead of diagnostic ones in Home Assistant.