### PR TITLE
Use C++17 concatenated namespace syntax

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -96,7 +96,6 @@ Checks: >-
   -modernize-avoid-variadic-functions,
   -modernize-avoid-c-arrays,
   -modernize-avoid-c-style-cast,
-  -modernize-concat-nested-namespaces,
   -modernize-macro-to-enum,
   -modernize-return-braced-init-list,
   -modernize-type-traits,

--- a/components/atorch_dl24/atorch_dl24.cpp
+++ b/components/atorch_dl24/atorch_dl24.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/version.h"
 
-namespace esphome {
-namespace atorch_dl24 {
+namespace esphome::atorch_dl24 {
 
 static const char *const TAG = "atorch_dl24";
 
@@ -487,5 +486,4 @@ void AtorchDL24::publish_state_(text_sensor::TextSensor *text_sensor, const std:
   text_sensor->publish_state(state);
 }
 
-}  // namespace atorch_dl24
-}  // namespace esphome
+}  // namespace esphome::atorch_dl24

--- a/components/atorch_dl24/atorch_dl24.h
+++ b/components/atorch_dl24/atorch_dl24.h
@@ -13,8 +13,7 @@
 namespace espbt = esphome::esp32_ble_tracker;
 #endif
 
-namespace esphome {
-namespace atorch_dl24 {
+namespace esphome::atorch_dl24 {
 
 class AtorchDL24 :
 #ifdef USE_ESP32
@@ -127,5 +126,4 @@ class AtorchDL24 :
   uint32_t throttle_{0};
 };
 
-}  // namespace atorch_dl24
-}  // namespace esphome
+}  // namespace esphome::atorch_dl24

--- a/components/atorch_dl24/button/atorch_button.cpp
+++ b/components/atorch_dl24/button/atorch_button.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace atorch_dl24 {
+namespace esphome::atorch_dl24 {
 
 static const char *const TAG = "atorch_dl24.button";
 
@@ -18,5 +17,4 @@ void AtorchButton::press_action() {
   this->parent_->write_register(device_type, this->holding_register_, 0x00000000);
 }
 
-}  // namespace atorch_dl24
-}  // namespace esphome
+}  // namespace esphome::atorch_dl24

--- a/components/atorch_dl24/button/atorch_button.h
+++ b/components/atorch_dl24/button/atorch_button.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/button/button.h"
 
-namespace esphome {
-namespace atorch_dl24 {
+namespace esphome::atorch_dl24 {
 
 class AtorchDL24;
 class AtorchButton : public button::Button, public Component {
@@ -22,5 +21,4 @@ class AtorchButton : public button::Button, public Component {
   uint8_t holding_register_;
 };
 
-}  // namespace atorch_dl24
-}  // namespace esphome
+}  // namespace esphome::atorch_dl24


### PR DESCRIPTION
The `modernize-concat-nested-namespaces` check is active in ESPHome's CI. All nested namespace blocks are replaced with `namespace esphome::X` syntax. The `.clang-tidy` is synced to the current ESPHome dev version.