### PR TITLE
Move BLE MAC address to secrets.yaml

### DIFF
--- a/esp32-ac-meter-example.yaml
+++ b/esp32-ac-meter-example.yaml
@@ -1,7 +1,6 @@
 substitutions:
   name: atorch-ac-meter
   external_components_source: github://syssi/esphome-atorch-dl24@main
-  dl24_mac_address: !secret dl24_mac_address
   project_version: 2.4.0
   device_description: "Monitor and control a Atorch meter via bluetooth"
 
@@ -52,7 +51,7 @@ esp32_ble_tracker:
     active: false
 
 ble_client:
-  - mac_address: ${dl24_mac_address}
+  - mac_address: !secret dl24_mac_address
     id: client0
 
 atorch_dl24:

--- a/esp32-dc-meter-example-advanced-multiple-devices.yaml
+++ b/esp32-dc-meter-example-advanced-multiple-devices.yaml
@@ -3,8 +3,6 @@ substitutions:
   device0: meter0
   device1: meter1
   external_components_source: github://syssi/esphome-atorch-dl24@main
-  dl24_mac_address0: !secret dl24_mac_address0
-  dl24_mac_address1: !secret dl24_mac_address1
   project_version: 2.4.0
   device_description: "Monitor and control two Atorch meters via bluetooth"
 
@@ -61,9 +59,9 @@ esp32_ble_tracker:
     active: false
 
 ble_client:
-  - mac_address: ${dl24_mac_address0}
+  - mac_address: !secret dl24_mac_address0
     id: client0
-  - mac_address: ${dl24_mac_address1}
+  - mac_address: !secret dl24_mac_address1
     id: client1
 
 atorch_dl24:

--- a/esp32-dc-meter-example.yaml
+++ b/esp32-dc-meter-example.yaml
@@ -1,7 +1,6 @@
 substitutions:
   name: atorch-dc-meter
   external_components_source: github://syssi/esphome-atorch-dl24@main
-  dl24_mac_address: !secret dl24_mac_address
   project_version: 2.4.0
   device_description: "Monitor and control a Atorch meter via bluetooth"
 
@@ -52,7 +51,7 @@ esp32_ble_tracker:
     active: false
 
 ble_client:
-  - mac_address: ${dl24_mac_address}
+  - mac_address: !secret dl24_mac_address
     id: client0
 
 atorch_dl24:

--- a/esp32-usb-meter-example.yaml
+++ b/esp32-usb-meter-example.yaml
@@ -1,7 +1,6 @@
 substitutions:
   name: atorch-usb-meter
   external_components_source: github://syssi/esphome-atorch-dl24@main
-  dl24_mac_address: !secret dl24_mac_address
   project_version: 2.4.0
   device_description: "Monitor and control a Atorch meter via bluetooth"
 
@@ -52,7 +51,7 @@ esp32_ble_tracker:
     active: false
 
 ble_client:
-  - mac_address: ${dl24_mac_address}
+  - mac_address: !secret dl24_mac_address
     id: client0
 
 atorch_dl24:

--- a/test-esp32.sh
+++ b/test-esp32.sh
@@ -6,4 +6,4 @@ else
   C="components"
 fi
 
-esphome -s external_components_source $C -s dl24_mac_address 41:B8:12:0A:A8:37 ${1:-run} ${2:-esp32-usb-meter-example-faker.yaml}
+esphome -s external_components_source $C ${1:-run} ${2:-esp32-usb-meter-example-faker.yaml}

--- a/tests/esp32-atorch-dt3010.yaml
+++ b/tests/esp32-atorch-dt3010.yaml
@@ -4,7 +4,6 @@
 substitutions:
   name: atorch-dc-meter
   external_components_source: github://syssi/esphome-atorch-dl24@main
-  dl24_mac_address: !secret dl24_mac_address
   project_version: 2.4.0
   device_description: "Monitor and control a Atorch meter via bluetooth"
 
@@ -50,7 +49,7 @@ mqtt:
 esp32_ble_tracker:
 
 ble_client:
-  - mac_address: ${dl24_mac_address}
+  - mac_address: !secret dl24_mac_address
     id: ble_client0
 
 atorch_dl24:

--- a/tests/esp32-atorch-j7-c.yaml
+++ b/tests/esp32-atorch-j7-c.yaml
@@ -1,7 +1,6 @@
 substitutions:
   name: atorch-usb-meter
   external_components_source: github://syssi/esphome-atorch-dl24@main
-  dl24_mac_address: !secret dl24_mac_address
   project_version: 2.4.0
   device_description: "Monitor and control a Atorch meter via bluetooth"
 
@@ -47,7 +46,7 @@ mqtt:
 esp32_ble_tracker:
 
 ble_client:
-  - mac_address: ${dl24_mac_address}
+  - mac_address: !secret dl24_mac_address
     id: ble_client0
 
 atorch_dl24:

--- a/tests/esp32-atorch-s1.yaml
+++ b/tests/esp32-atorch-s1.yaml
@@ -1,7 +1,6 @@
 substitutions:
   name: atorch-ac-meter
   external_components_source: github://syssi/esphome-atorch-dl24@main
-  dl24_mac_address: !secret dl24_mac_address
   project_version: 2.4.0
   device_description: "Monitor and control a Atorch meter via bluetooth"
 
@@ -47,7 +46,7 @@ mqtt:
 esp32_ble_tracker:
 
 ble_client:
-  - mac_address: ${dl24_mac_address}
+  - mac_address: !secret dl24_mac_address
     id: ble_client0
 
 atorch_dl24:

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -38,7 +38,7 @@ esp32_ble_tracker:
     active: false
 
 ble_client:
-  - mac_address: 41:B8:12:0A:A8:37
+  - mac_address: !secret dl24_mac_address
     id: ble_client0
 
 atorch_dl24:


### PR DESCRIPTION
## Summary

- Reference the BLE client MAC address via `!secret dl24_mac_address` directly in `ble_client:` instead of routing through a YAML substitution
- Remove the now-unused substitution entries
- Fix hard-coded MAC address in the esp32c6 compatibility test